### PR TITLE
Corrected keypress: 'i' now triggers EvKeyPressI

### DIFF
--- a/smacc_client_library/keyboard_client/include/keyboard_client/client_behaviors/cb_default_keyboard_behavior.h
+++ b/smacc_client_library/keyboard_client/include/keyboard_client/client_behaviors/cb_default_keyboard_behavior.h
@@ -39,7 +39,7 @@ public:
                 postKeyEvent<EvKeyPressG<CbDefaultKeyboardBehavior, TOrthogonal>>();
             else if (character == 'h')
                 postKeyEvent<EvKeyPressH<CbDefaultKeyboardBehavior, TOrthogonal>>();
-            else if (character == 'y')
+            else if (character == 'i')
                 postKeyEvent<EvKeyPressI<CbDefaultKeyboardBehavior, TOrthogonal>>();
             else if (character == 'j')
                 postKeyEvent<EvKeyPressJ<CbDefaultKeyboardBehavior, TOrthogonal>>();


### PR DESCRIPTION
Pressing 'y' was triggering EvKeyPressI. This was also preventing EvKeyPressY from triggering.